### PR TITLE
Fixing race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/projectdiscovery/ipranger
 
 go 1.14
-
 require (
 	github.com/projectdiscovery/blackrock v0.0.0-20210903102120-5a9d2412d21d // indirect
 	github.com/projectdiscovery/hmap v0.0.1


### PR DESCRIPTION
## Description
This PR introduces a `sync.Mutex` wrapping the internal ranger thread unsafe operations